### PR TITLE
Filter args passed to  for custom control

### DIFF
--- a/templates-admin/network-admin-setup.php
+++ b/templates-admin/network-admin-setup.php
@@ -18,7 +18,20 @@ switch ( $action ) {
 
 		// Just print a dropdown which we can redirect to the edit page.
 		// @todo Take account of wp_is_large_network() and AJAX paginate/search accordingly.
-		$blogs = wp_get_sites( array( 'public' => 1 ) );
+		/**
+		 * Allow for modification of the default arguments for grabbing blogs.
+		 *
+		 * Filters the array of arguments sent to `wp_get_sites()` so that
+		 * other options, such as choosing non-public blogs, can be used.
+		 *
+		 * @since 1.2.0
+		 *
+		 * @var array $args See `wp_get_sites()`
+		 */
+		$blogs_args = apply_filters( 'aggregator_get_sites_arguments', array(
+			'public' => 1,
+		) );
+		$blogs = wp_get_sites( $blogs_args );
 		?>
 		<div class="wrap">
 			<h2><?php esc_html_e( 'Add New Sync Job' ); ?></h2>


### PR DESCRIPTION
By default, only public sites are configurable. This filter adds the ability for themes and plugins to allow non-public sites to be source or portal sites for the aggregator.