### PR TITLE
Better naming for jobs

### DIFF
--- a/class-aggregator-job.php
+++ b/class-aggregator-job.php
@@ -35,6 +35,13 @@ class Aggregator_Job {
 	public $post_id;
 
 	/**
+	 * Custom title for this job
+	 *
+	 * @var string
+	 */
+	public $title;
+
+	/**
 	 * ID of the blog we're currently on
 	 *
 	 * @var int
@@ -117,6 +124,14 @@ class Aggregator_Job {
 
 				// Store the post ID for later.
 				$this->post_id = get_the_ID();
+
+				// Store the title for later, if we have one.
+				$title = get_the_title();
+				if ( 'Auto Draft' === $title || is_numeric( $title ) ) {
+					$this->title = sprintf( __( 'Job #%d', 'aggregator' ), $this->post_id );
+				} else {
+					$this->title = $title;
+				}
 
 				// Store post types for later.
 				$this->post_types = get_post_meta( get_the_ID(), '_aggregator_post_types', true );

--- a/class-aggregator-jobs-list-table.php
+++ b/class-aggregator-jobs-list-table.php
@@ -19,7 +19,7 @@ if ( class_exists( 'WP_List_Table' ) ) {
 			parent::__construct( array(
 				'singular' => 'wp_list_aggregator_job', // Singular label
 				'plural' => 'wp_list_aggregator_jobs', // plural label, also this well be one of the table css class
-				'ajax'   => false,// We won't support Ajax for this table.
+				'ajax' => false, // We won't support Ajax for this table.
 			) );
 
 		}
@@ -103,7 +103,31 @@ if ( class_exists( 'WP_List_Table' ) ) {
 							) );
 							$actions['delete']	= '<a href="' . esc_url( $delete_url ) . '">' . esc_html__( 'Delete' ) . '</a>';
 
-							echo "<td $attributes>" . esc_html( $job->source->blogname ) . ' (' . esc_html( $job->source->domain ) . ')' . $this->row_actions( $actions ) . '</td>'; // XSS ok.
+							echo "<td $attributes>";
+
+							// Job title.
+							echo '<strong>' . esc_html( $job->title ) . '</strong><br/>';
+
+							// Job source site.
+							echo esc_html__( 'Source: ', 'aggregator' );
+							echo sprintf(
+								'<a href="%s">%s</a>',
+								esc_url( get_admin_url( $job->source->blog_id ) ),
+								esc_html( $job->source->blogname )
+							) . '<br/>';
+
+							// Job portal site.
+							echo esc_html__( 'Portal: ', 'aggregator' );
+							echo sprintf(
+								'<a href="%s">%s</a>',
+								esc_url( get_admin_url( $job->portal->blog_id ) ),
+								esc_html( $job->portal->blogname )
+							);
+
+							// Admin actions.
+							echo $this->row_actions( $actions ); // XSS ok.
+
+							echo '</td>';
 
 							break;
 

--- a/class-aggregator.php
+++ b/class-aggregator.php
@@ -647,8 +647,10 @@ class Aggregator extends Aggregator_Plugin {
 		);
 
 		// Queue up only on post add/edit screen for our post type.
-		if ( 'aggregator_job' === $current_screen->post_type
-			&& ( 'post.php' === $pagenow || 'post-new.php' === $pagenow ) ) {
+		if (
+			'aggregator_job' === $current_screen->post_type
+			&& ( 'post.php' === $pagenow || 'post-new.php' === $pagenow )
+		) {
 
 			// Queue the script for inclusion.
 			wp_enqueue_script( 'aggregator_job_edit' );
@@ -809,11 +811,11 @@ class Aggregator extends Aggregator_Plugin {
 		$id = isset( $_GET['id'] ) ? intval( $_GET['id'] ) : false; // Input var okay.
 
 		// Set the column headers.
-		if ( $id ) {
+		if ( false !== $id ) {
 			$column_headers = array(
-				'col_source' => __( 'Sites' ),
-				'col_syncing' => __( 'Syncing' ),
-				'col_author' => __( 'Author' ),
+				'col_source' => __( 'Sites', 'aggregator' ),
+				'col_syncing' => __( 'Syncing', 'aggregator' ),
+				'col_author' => __( 'Author', 'aggregator' ),
 			);
 		}
 
@@ -833,7 +835,8 @@ class Aggregator extends Aggregator_Plugin {
 
 		// Only alter priority on our job post type.
 		if ( 'aggregator_job' === $current_screen->post_type ) {
-			$priority = 'default'; }
+			$priority = 'default';
+		}
 
 		return $priority;
 	}

--- a/class-aggregator.php
+++ b/class-aggregator.php
@@ -381,7 +381,7 @@ class Aggregator extends Aggregator_Plugin {
 			'public' => false, // Only access through our network admin UI.
 			'show_ui' => true, // Otherwise we can't use post edit screens.
 			'show_in_menu' => false, // Otherwise uses show_ui value.
-			'supports' => array( 'author' ),
+			'supports' => array( 'title', 'author' ),
 			'register_meta_box_cb' => array( $this, 'meta_boxes' ),
 			'taxonomies' => $this->get_taxonomies_for_sync_settings(),
 			'query_var' => false,

--- a/class-aggregator.php
+++ b/class-aggregator.php
@@ -486,32 +486,34 @@ class Aggregator extends Aggregator_Plugin {
 		// Grab the portal ID from the REQUEST vars hopefully.
 		if ( isset( $_GET['portal'] ) ) { // Input var okay.
 			$portal = intval( $_GET['portal'] ); // Input var okay.
-			$portal = get_blog_details( $portal );
 		} else {
-			return;
+			$portal = get_post_meta( $post->ID, '_aggregator_portal', true );
 		}
+		$portal = get_blog_details( $portal );
 
 		// ...and the current blog.
 		$source = get_blog_details( get_current_blog_id() );
 
-		// @todo style this to remove the border, heading and background.
-		echo '<h1>' . sprintf(
-			esc_html__( '%s to %s' ),
-			esc_html( $source->domain . $source->path ),
-			esc_html( $portal->domain . $portal->path )
-		) . '</h1>';
+		// Show the source and portal clearly.
+		echo '<p>' . esc_html__( 'Source: ', 'aggregator' );
+		echo sprintf(
+			'<a href="%s">%s</a>',
+			esc_url( get_admin_url( $source->blog_id ) ),
+			esc_html( $source->blogname )
+		) . '<br/>';
 
-		// Get the portal ID, wherever it may be.
-		if ( isset( $_GET['portal'] ) ) { // Input var okay.
-			$portal = intval( $_GET['portal'] ); // Input var okay.
-		} else {
-			$portal = get_post_meta( $post->ID, '_aggregator_portal', true );
-		}
+		// Job portal site.
+		echo esc_html__( 'Portal: ', 'aggregator' );
+		echo sprintf(
+			'<a href="%s">%s</a>',
+			esc_url( get_admin_url( $portal->blog_id ) ),
+			esc_html( $portal->blogname )
+		) . '</p>';
 
 		// Sneak the portal ID in here as a hidden field.
 		echo sprintf(
 			'<input type="hidden" name="portal" value="%d">',
-			esc_attr( $portal )
+			esc_attr( $portal->blog_id )
 		);
 
 	}


### PR DESCRIPTION
Fixes #33 

* Gives jobs a default name, using the ID
* Enables title support for jobs
* Improves the display of the source/portal on the edit job screen