### PR TITLE
Use `get_sites()` over `wp_get_sites()`

### DIFF
--- a/class-aggregator-portals-list-table.php
+++ b/class-aggregator-portals-list-table.php
@@ -44,10 +44,20 @@ if ( class_exists( 'WP_List_Table' ) ) {
 
 			// Make sure we have an array for $this->items.
 			if ( ! is_array( $this->items ) ) {
-				$this->items = array(); }
+				$this->items = array();
+			}
 
 			// Get all the blogs.
-			$blogs = wp_get_sites( array( 'public' => 1 ) );
+			/** This filter is documented in templates-admin/network-admin-setup.php */
+			$blogs_args = apply_filters( 'aggregator_get_sites_arguments', array(
+				'public' => 1,
+			) );
+			global $wp_version;
+			if ( -1 === version_compare( $wp_version, '4.6' ) ) {
+				$blogs = wp_get_sites( $blogs_args );
+			} else {
+				$blogs = get_sites( $blogs_args );
+			}
 
 			// Our array of portals.
 			$portals = array();

--- a/class-aggregator-portals-list-table.php
+++ b/class-aggregator-portals-list-table.php
@@ -48,16 +48,7 @@ if ( class_exists( 'WP_List_Table' ) ) {
 			}
 
 			// Get all the blogs.
-			/** This filter is documented in templates-admin/network-admin-setup.php */
-			$blogs_args = apply_filters( 'aggregator_get_sites_arguments', array(
-				'public' => 1,
-			) );
-			global $wp_version;
-			if ( -1 === version_compare( $wp_version, '4.6' ) ) {
-				$blogs = wp_get_sites( $blogs_args );
-			} else {
-				$blogs = get_sites( $blogs_args );
-			}
+			$blogs = Aggregator::get_sites();
 
 			// Our array of portals.
 			$portals = array();
@@ -65,8 +56,8 @@ if ( class_exists( 'WP_List_Table' ) ) {
 			// Check if we have sync jobs for those sites.
 			foreach ( $blogs as $blog ) {
 
-				if ( $sync_blogs = get_site_option( "aggregator_{$blog['blog_id']}_source_blogs" ) ) {
-					$portals[ $blog['blog_id'] ] = $sync_blogs;
+				if ( $sync_blogs = get_site_option( "aggregator_{$blog->blog_id}_source_blogs" ) ) {
+					$portals[ $blog->blog_id ] = $sync_blogs;
 				}
 
 				unset( $sync_blogs );
@@ -75,7 +66,9 @@ if ( class_exists( 'WP_List_Table' ) ) {
 
 			if ( ! empty( $portals ) ) {
 				$this->items = $portals;
-			} else { 				$this->items = array(); }
+			} else {
+				$this->items = array();
+			}
 
 		}
 

--- a/class-aggregator.php
+++ b/class-aggregator.php
@@ -317,14 +317,18 @@ class Aggregator extends Aggregator_Plugin {
 	 */
 	public function get_jobs() {
 
-		// Get $wpdb so that we can use the network (site) ID later on.
-		global $wpdb;
-
 		// Get a list of sites.
 		// @todo We need to consider is_large_network() at some point.
-		$blogs = wp_get_sites( array(
-			'network_id' => $wpdb->siteid,
+		/** This filter is documented in templates-admin/network-admin-setup.php */
+		$blogs_args = apply_filters( 'aggregator_get_sites_arguments', array(
+			'public' => 1,
 		) );
+		global $wp_version;
+		if ( -1 === version_compare( $wp_version, '4.6' ) ) {
+			$blogs = wp_get_sites( $blogs_args );
+		} else {
+			$blogs = get_sites( $blogs_args );
+		}
 
 		// Should never be empty, but hey, let's play safe.
 		if ( empty( $blogs ) ) {

--- a/class-aggregator.php
+++ b/class-aggregator.php
@@ -318,17 +318,7 @@ class Aggregator extends Aggregator_Plugin {
 	public function get_jobs() {
 
 		// Get a list of sites.
-		// @todo We need to consider is_large_network() at some point.
-		/** This filter is documented in templates-admin/network-admin-setup.php */
-		$blogs_args = apply_filters( 'aggregator_get_sites_arguments', array(
-			'public' => 1,
-		) );
-		global $wp_version;
-		if ( -1 === version_compare( $wp_version, '4.6' ) ) {
-			$blogs = wp_get_sites( $blogs_args );
-		} else {
-			$blogs = get_sites( $blogs_args );
-		}
+		$blogs = Aggregator::get_sites();
 
 		// Should never be empty, but hey, let's play safe.
 		if ( empty( $blogs ) ) {
@@ -346,11 +336,11 @@ class Aggregator extends Aggregator_Plugin {
 			foreach ( $blogs as $source ) {
 
 				// Don't try and find any blogs syncing to themselves.
-				if ( $portal['blog_id'] === $source['blog_id'] ) {
+				if ( $portal->blog_id === $source->blog_id ) {
 					continue; }
 
 				// Get any jobs.
-				$job = new Aggregator_Job( $portal['blog_id'], $source['blog_id'] );
+				$job = new Aggregator_Job( $portal->blog_id, $source->blog_id );
 				if ( is_null( $job->post_id ) ) {
 					continue;
 				} else {
@@ -929,7 +919,7 @@ class Aggregator extends Aggregator_Plugin {
 	/**
 	 * Redirect aggregated posts to the original post
 	 */
-	function template_redirect() {
+	public function template_redirect() {
 
 		// Get the original permalink (if any).
 		$original_permalink = get_post_meta( get_the_ID(), '_aggregator_permalink', true );
@@ -952,6 +942,53 @@ class Aggregator extends Aggregator_Plugin {
 		}
 
 	}
+
+	/**
+	 * Helper function for getting a list of blogs.
+	 *
+	 * @todo Take account of wp_is_large_network() and AJAX paginate/search accordingly.
+	 *
+	 * @return array Array of site objects
+	 */
+	static function get_sites() {
+
+		/**
+		 * Allow for modification of the default arguments for grabbing blogs.
+		 *
+		 * Filters the array of arguments sent to `wp_get_sites()` so that
+		 * other options, such as choosing non-public blogs, can be used.
+		 *
+		 * @since 1.2.0
+		 *
+		 * @var array $args See `wp_get_sites()`
+		 */
+		$blogs_args = apply_filters( 'aggregator_get_sites_arguments', array(
+			'public' => 1,
+		) );
+
+		// Use `get_sites()` in 4.6 and above because `wp_get_sites()` is deprecated.
+		global $wp_version;
+		if ( -1 === version_compare( $wp_version, '4.6' ) ) {
+			$blogs = wp_get_sites( $blogs_args );
+			$new_blogs = array();
+		} else {
+			$blogs = get_sites( $blogs_args );
+		}
+
+		// Convert array output into objects to make our lives easier.
+		if ( isset( $new_blogs ) ) {
+			for ( $i=0; $i < count( $blogs ); $i++ ) {
+				$new_blogs[ $i ] = (object) $blogs[ $i ];
+			}
+
+			$blogs = $new_blogs;
+		}
+
+		return $blogs;
+
+	}
+
+
 } // END Aggregator class
 
 $aggregator = new Aggregator();

--- a/templates-admin/network-admin-setup.php
+++ b/templates-admin/network-admin-setup.php
@@ -17,26 +17,7 @@ switch ( $action ) {
 	case 'add':
 
 		// Just print a dropdown which we can redirect to the edit page.
-		// @todo Take account of wp_is_large_network() and AJAX paginate/search accordingly.
-		/**
-		 * Allow for modification of the default arguments for grabbing blogs.
-		 *
-		 * Filters the array of arguments sent to `wp_get_sites()` so that
-		 * other options, such as choosing non-public blogs, can be used.
-		 *
-		 * @since 1.2.0
-		 *
-		 * @var array $args See `wp_get_sites()`
-		 */
-		$blogs_args = apply_filters( 'aggregator_get_sites_arguments', array(
-			'public' => 1,
-		) );
-		global $wp_version;
-		if ( -1 === version_compare( $wp_version, '4.6' ) ) {
-			$blogs = wp_get_sites( $blogs_args );
-		} else {
-			$blogs = get_sites( $blogs_args );
-		}
+		$blogs = Aggregator::get_sites();
 		?>
 		<div class="wrap">
 			<h2><?php esc_html_e( 'Add New Sync Job' ); ?></h2>
@@ -48,7 +29,7 @@ switch ( $action ) {
 						<?php
 						foreach ( $blogs as $blog ) {
 							?>
-							<option value="<?php echo esc_attr( $blog['blog_id'] ); ?>"><?php echo esc_html( ( SUBDOMAIN_INSTALL ) ? $blog['domain'] : $blog['path'] ); ?></option><?php
+							<option value="<?php echo esc_attr( $blog->blog_id ); ?>"><?php echo esc_html( ( SUBDOMAIN_INSTALL ) ? $blog->domain : $blog->path ); ?></option><?php
 						}
 						?>
 					</select>
@@ -61,7 +42,7 @@ switch ( $action ) {
 						<?php
 						foreach ( $blogs as $blog ) {
 							?>
-							<option value="<?php echo esc_attr( $blog['blog_id'] ); ?>"><?php echo esc_html( ( SUBDOMAIN_INSTALL ) ? $blog['domain'] : $blog['path'] ); ?></option><?php
+							<option value="<?php echo esc_attr( $blog->blog_id ); ?>"><?php echo esc_html( ( SUBDOMAIN_INSTALL ) ? $blog->domain : $blog->path ); ?></option><?php
 						}
 						?>
 					</select>

--- a/templates-admin/network-admin-setup.php
+++ b/templates-admin/network-admin-setup.php
@@ -31,7 +31,12 @@ switch ( $action ) {
 		$blogs_args = apply_filters( 'aggregator_get_sites_arguments', array(
 			'public' => 1,
 		) );
-		$blogs = wp_get_sites( $blogs_args );
+		global $wp_version;
+		if ( -1 === version_compare( $wp_version, '4.6' ) ) {
+			$blogs = wp_get_sites( $blogs_args );
+		} else {
+			$blogs = get_sites( $blogs_args );
+		}
 		?>
 		<div class="wrap">
 			<h2><?php esc_html_e( 'Add New Sync Job' ); ?></h2>


### PR DESCRIPTION
Moves all uses of `wp_get_sites()` into a helper function that;

* uses `get_sites()` instead in v4.6 and above
* falls back to `wp_get_sites()` in earlier WP versions
* refactors the output of `wp_get_sites()` into an object so that the plugin can assume `get_sites()`

Fixes #16