### PR TITLE
Make clone site labels filterable

### DIFF
--- a/class-aggregator.php
+++ b/class-aggregator.php
@@ -132,11 +132,23 @@ class Aggregator extends Aggregator_Plugin {
 				$new_actions['view'] = $actions['view'];
 			}
 
-			// Contsruct a link for detaching the post
+			// Construct a link for detaching the post
 			$edit_post_link = get_edit_post_link( $post->ID );
 			$detach_post_link = str_replace( 'action=edit', 'action=aggregator_detach', $edit_post_link );
 
-			$new_actions['detach'] = sprintf( '<a href="%s">Detach</a>', $detach_post_link );
+			/**
+			 * Choose a label for Detach action link.
+			 *
+			 * Based on the post data, keep the default 'Detach' label or relabel with your own.
+			 *
+			 * @since 1.2.0
+			 *
+			 * @param string Default label of 'Detach'.
+			 * @param WP_Post $post Post object
+			 */
+			$label = apply_filters( 'aggregator_detach_label', __( 'Detach', 'aggregator' ), $post );
+
+			$new_actions['detach'] = sprintf( '<a href="%s">%s</a>', $detach_post_link, $label );
 
 			$actions = $new_actions;
 
@@ -206,7 +218,7 @@ class Aggregator extends Aggregator_Plugin {
 		 * @since 1.2.0
 		 *
 		 * @param string Default label of 'Aggregated'.
-		 * @param string $post WP_Post Post object
+		 * @param WP_Post $post Post object
 		 */
 		$label = apply_filters( 'aggregator_aggregated_label', __( 'Aggregated', 'aggregator' ), $post );
 

--- a/class-aggregator.php
+++ b/class-aggregator.php
@@ -148,7 +148,7 @@ class Aggregator extends Aggregator_Plugin {
 			 */
 			$label = apply_filters( 'aggregator_detach_label', __( 'Detach', 'aggregator' ), $post );
 
-			$new_actions['detach'] = sprintf( '<a href="%s">%s</a>', $detach_post_link, $label );
+			$new_actions['detach'] = sprintf( '<a href="%s">%s</a>', $detach_post_link, esc_html( $label ) );
 
 			$actions = $new_actions;
 

--- a/class-aggregator.php
+++ b/class-aggregator.php
@@ -198,9 +198,21 @@ class Aggregator extends Aggregator_Plugin {
 			$post = get_post();
 		}
 
+		/**
+		 * Choose a label for Aggregated post states.
+		 *
+		 * Based on the post data, keep the default 'Aggregated' label or relabel with your own.
+		 *
+		 * @since 1.2.0
+		 *
+		 * @param string Default label of 'Aggregated'.
+		 * @param string $post WP_Post Post object
+		 */
+		$label = apply_filters( 'aggregator_aggregated_label', __( 'Aggregated', 'aggregator' ), $post );
+
 		// Operate only on synced posts.
 		if ( get_post_meta( $post->ID, '_aggregator_orig_blog_id', true ) ) {
-			$post_states[] = esc_html__( 'Aggregated', 'aggregator' );
+			$post_states[] = esc_html( $label );
 		}
 
 		return $post_states;


### PR DESCRIPTION
The labels "Aggregated" and "Detached" do not match every editorial language and it would be useful for these labels to be modifiable to match a different naming pattern that editors are more likely to recognize. For example a user might expect to see "Clone" instead of "Detach" or 'Distributed" instead of "Aggregated".

This PR adds filters for the main labels so that a developer can easily override them with their own label and make the system feel more customized to the client. I added labels for "Detach" and "Aggregated" as these were the main 2 I could see wanting to be customized but I'm happy to add more to this request if you can think of any more that would be useful to modify.