### PR TITLE
Delete _orig_terms upon post detaching

### DIFF
--- a/class-aggregator.php
+++ b/class-aggregator.php
@@ -162,6 +162,7 @@ class Aggregator extends Aggregator_Plugin {
 		delete_post_meta( $post_id, '_aggregator_orig_post_id' );
 		delete_post_meta( $post_id, '_aggregator_orig_blog_id' );
 		delete_post_meta( $post_id, '_aggregator_permalink' );
+		delete_post_meta( $post_id, '_orig_terms' );
 
 	}
 


### PR DESCRIPTION
There's an orphan post meta item left when you detach a post ans that is `_orig_terms`. This Pull Request cleans up this extra post meta item as I could find no further use for this value once a post is detached.

Resolves #47 