### PR TITLE
Add actions to Aggregation create, update and delete methods

### DIFF
--- a/class-aggregate.php
+++ b/class-aggregate.php
@@ -884,6 +884,17 @@ class Aggregate extends Aggregator_Plugin {
 			$new_post_data->post_status = apply_filters( 'aggregator_post_status', $orig_post_data['post_status'] );
 			wp_update_post( $new_post_data );
 
+
+			/**
+			 * Do an action after the post has been successfully created on the destination site.
+			 *
+			 * @param WP_Post $new_post_data
+			 * @param WP_Post $orig_post_data
+			 * @param int     $sync_destination
+			 * @param int     $current_blog
+			 */
+			do_action( 'aggregator_after_push_new_post', $new_post_data, $orig_post_data, $sync_destination, $current_blog->blog_id );
+
 			// Switch back to source blog.
 			restore_current_blog();
 

--- a/class-aggregate.php
+++ b/class-aggregate.php
@@ -350,17 +350,17 @@ class Aggregate extends Aggregator_Plugin {
 			$target_post_id = $this->get_portal_blog_post_id( $post_id, $current_blog->blog_id );
 			if ( false !== $target_post_id ) {
 				wp_delete_post( $target_post_id, true );
-			}
 
-			/**
-			 * Do an action after the post has been successfully deleted on a portal site.
-			 *
-			 * @param int $target_post_id Portal site deleted post ID
-			 * @param int $post_id Original post ID
-			 * @param int $portal Portal site ID
-			 * @param int $current_blog Original site ID
-			 */
-			do_action( 'aggregator_after_delete_post', $target_post_id, $post_id, $portal, $current_blog->blog_id );
+				/**
+				 * Do an action after the post has been successfully deleted on a portal site.
+				 *
+				 * @param int $target_post_id Portal site deleted post ID
+				 * @param int $post_id Original post ID
+				 * @param int $portal Portal site ID
+				 * @param int $current_blog Original site ID
+				 */
+				do_action( 'aggregator_after_delete_post', $target_post_id, $post_id, $portal, $current_blog->blog_id );
+			}
 
 			// Back to the current blog.
 			restore_current_blog();
@@ -906,7 +906,7 @@ class Aggregate extends Aggregator_Plugin {
 			 * @param int     $current_blog Original site ID
 			 * @param bool    $updated Whether site is updated or not
 			 */
-			do_action( 'aggregator_after_push_new_post', $new_post_data, $orig_post_data, $sync_destination, $current_blog->blog_id, $updated );
+			do_action( 'aggregator_after_push_post_data', $new_post_data, $orig_post_data, $sync_destination, $current_blog->blog_id, $updated );
 
 			// Switch back to source blog.
 			restore_current_blog();

--- a/class-aggregate.php
+++ b/class-aggregate.php
@@ -352,6 +352,16 @@ class Aggregate extends Aggregator_Plugin {
 				wp_delete_post( $target_post_id, true );
 			}
 
+			/**
+			 * Do an action after the post has been successfully deleted on a portal site.
+			 *
+			 * @param int $target_post_id Portal site deleted post ID
+			 * @param int $post_id Original post ID
+			 * @param int $portal Portal site ID
+			 * @param int $current_blog Original site ID
+			 */
+			do_action( 'aggregator_after_delete_post', $target_post_id, $post_id, $portal, $current_blog->blog_id );
+
 			// Back to the current blog.
 			restore_current_blog();
 
@@ -883,7 +893,7 @@ class Aggregate extends Aggregator_Plugin {
 			 */
 			$new_post_data->post_status = apply_filters( 'aggregator_post_status', $orig_post_data['post_status'] );
 			wp_update_post( $new_post_data );
-			
+
 			// Get boolean on if post is updated or brand new.
 			$updated = ( false !== $target_post_id );
 

--- a/class-aggregate.php
+++ b/class-aggregate.php
@@ -895,7 +895,7 @@ class Aggregate extends Aggregator_Plugin {
 			wp_update_post( $new_post_data );
 
 			// Get boolean on if post is updated or brand new.
-			$updating     = ( false !== $target_post_id );
+			$updating     = ( false !== $portal_target_post_id );
 			$new_post_id = ( $updating ) ? $portal_target_post_id : $new_post_data->ID;
 
 			/**

--- a/class-aggregate.php
+++ b/class-aggregate.php
@@ -825,8 +825,8 @@ class Aggregate extends Aggregator_Plugin {
 			$orig_post_data['author'] = $this->prepare_author_id( $orig_post_data['author'], $sync_destination );
 
 			// Acquire ID and update post (or insert post and acquire ID).
-			$target_post_id = $this->get_portal_blog_post_id( $orig_post_id, $current_blog->blog_id );
-			if ( false !== $target_post_id ) {
+			$portal_target_post_id = $this->get_portal_blog_post_id( $orig_post_id, $current_blog->blog_id );
+			if ( false !== $portal_target_post_id ) {
 				$target_post_id = $orig_post_data['ID'];
 				wp_update_post( $orig_post_data );
 			} else {
@@ -895,18 +895,19 @@ class Aggregate extends Aggregator_Plugin {
 			wp_update_post( $new_post_data );
 
 			// Get boolean on if post is updated or brand new.
-			$updated = ( false !== $target_post_id );
+			$updating     = ( false !== $target_post_id );
+			$new_post_id = ( $updating ) ? $portal_target_post_id : $new_post_data->ID;
 
 			/**
 			 * Do an action after the post has been successfully created on the destination site.
 			 *
-			 * @param int  $new_post_data Fresh post ID
+			 * @param int  $new_post_id Fresh post ID
 			 * @param int  $orig_post_id Original post ID
 			 * @param int  $sync_destination Destination site ID
 			 * @param int  $current_blog Original site ID
-			 * @param bool $updated Whether site is updated or not
+			 * @param bool $updating Whether post is updating (true) or a new post
 			 */
-			do_action( 'aggregator_after_push_post_data', $new_post_data->ID, $orig_post_id, $sync_destination, $current_blog->blog_id, $updated );
+			do_action( 'aggregator_after_push_post_data', $new_post_id, $orig_post_id, $sync_destination, $current_blog->blog_id, $updating );
 
 			// Switch back to source blog.
 			restore_current_blog();

--- a/class-aggregate.php
+++ b/class-aggregate.php
@@ -883,17 +883,20 @@ class Aggregate extends Aggregator_Plugin {
 			 */
 			$new_post_data->post_status = apply_filters( 'aggregator_post_status', $orig_post_data['post_status'] );
 			wp_update_post( $new_post_data );
-
+			
+			// Get boolean on if post is updated or brand new.
+			$updated = ( false !== $target_post_id );
 
 			/**
 			 * Do an action after the post has been successfully created on the destination site.
 			 *
-			 * @param WP_Post $new_post_data
-			 * @param WP_Post $orig_post_data
-			 * @param int     $sync_destination
-			 * @param int     $current_blog
+			 * @param WP_Post $new_post_data Fresh post data
+			 * @param WP_Post $orig_post_data Original post data
+			 * @param int     $sync_destination Destination site ID
+			 * @param int     $current_blog Original site ID
+			 * @param bool    $updated Whether site is updated or not
 			 */
-			do_action( 'aggregator_after_push_new_post', $new_post_data, $orig_post_data, $sync_destination, $current_blog->blog_id );
+			do_action( 'aggregator_after_push_new_post', $new_post_data, $orig_post_data, $sync_destination, $current_blog->blog_id, $updated );
 
 			// Switch back to source blog.
 			restore_current_blog();

--- a/class-aggregate.php
+++ b/class-aggregate.php
@@ -900,13 +900,13 @@ class Aggregate extends Aggregator_Plugin {
 			/**
 			 * Do an action after the post has been successfully created on the destination site.
 			 *
-			 * @param WP_Post $new_post_data Fresh post data
-			 * @param WP_Post $orig_post_data Original post data
-			 * @param int     $sync_destination Destination site ID
-			 * @param int     $current_blog Original site ID
-			 * @param bool    $updated Whether site is updated or not
+			 * @param int  $new_post_data Fresh post ID
+			 * @param int  $orig_post_id Original post ID
+			 * @param int  $sync_destination Destination site ID
+			 * @param int  $current_blog Original site ID
+			 * @param bool $updated Whether site is updated or not
 			 */
-			do_action( 'aggregator_after_push_post_data', $new_post_data, $orig_post_data, $sync_destination, $current_blog->blog_id, $updated );
+			do_action( 'aggregator_after_push_post_data', $new_post_data->ID, $orig_post_id, $sync_destination, $current_blog->blog_id, $updated );
 
 			// Switch back to source blog.
 			restore_current_blog();

--- a/class-aggregator.php
+++ b/class-aggregator.php
@@ -158,10 +158,23 @@ class Aggregator extends Aggregator_Plugin {
 			return;
 		}
 
+		$orig_post_id = get_post_meta( $post_id, '_aggregator_orig_post_id', true );
+		$orig_blog_id = get_post_meta( $post_id, '_aggregator_orig_blog_id', true );
+
 		// Delete the post meta that attaches this post to it's parent
 		delete_post_meta( $post_id, '_aggregator_orig_post_id' );
 		delete_post_meta( $post_id, '_aggregator_orig_blog_id' );
 		delete_post_meta( $post_id, '_aggregator_permalink' );
+
+		/**
+		 * Do an action after a post has been detached on a portal site.
+		 *
+		 * @param int $post_id Portal site post ID
+		 * @param int $orig_post_id Original post ID
+		 * @param int $portal Portal site ID
+		 * @param int $orig_blog_id Original site ID
+		 */
+		do_action( 'aggregator_after_detach_post', $post_id, $orig_post_id, get_current_blog_id(), $orig_blog_id );
 
 	}
 


### PR DESCRIPTION
We need to perform custom syncing work (related to images assigned by ID in post metadata) upon post creation and syncing and need a place to hook into to allow us to perform this work with some context passed through. This is a relatively early idea so am very open to feedback on what should be passed through and maybe if we need more `do_actions` in other places that I could add now.