### PR TITLE
Add filter for turning the network admin UI off

### DIFF
--- a/class-aggregator.php
+++ b/class-aggregator.php
@@ -214,14 +214,14 @@ class Aggregator extends Aggregator_Plugin {
 	 * @return void
 	 */
 	public function network_admin_menu() {
-
 		/**
-		 * Allow a user to turn the admin UI off.
+		 * Allow a theme or plugin to turn the admin UI off.
 		 *
 		 * Passing false back through this filter will allow a theme or plugin to
-		 * turn off the admin UI for aggregation jobs.
+		 * turn off the admin UI for aggregation jobs and exclusively control them
+		 * through the code.
 		 *
-		 * @param bool Whether or not to display the network UI.
+		 * @param bool $display Whether or not to display the network UI.
 		 */
 		if ( ! apply_filters( 'aggregator_display_ui', true ) ) {
 			return;

--- a/class-aggregator.php
+++ b/class-aggregator.php
@@ -221,6 +221,8 @@ class Aggregator extends Aggregator_Plugin {
 		 * turn off the admin UI for aggregation jobs and exclusively control them
 		 * through the code.
 		 *
+		 * @since 1.2.0
+		 *
 		 * @param bool $display Whether or not to display the network UI.
 		 */
 		if ( ! apply_filters( 'aggregator_display_ui', true ) ) {

--- a/class-aggregator.php
+++ b/class-aggregator.php
@@ -225,7 +225,7 @@ class Aggregator extends Aggregator_Plugin {
 		 *
 		 * @param bool $display Whether or not to display the network UI.
 		 */
-		if ( ! apply_filters( 'aggregator_display_ui', true ) ) {
+		if ( ! apply_filters( 'aggregator_display_network_ui', true ) ) {
 			return;
 		}
 

--- a/class-aggregator.php
+++ b/class-aggregator.php
@@ -214,6 +214,19 @@ class Aggregator extends Aggregator_Plugin {
 	 * @return void
 	 */
 	public function network_admin_menu() {
+
+		/**
+		 * Allow a user to turn the admin UI off.
+		 *
+		 * Passing false back through this filter will allow a theme or plugin to
+		 * turn off the admin UI for aggregation jobs.
+		 *
+		 * @param bool Whether or not to display the network UI.
+		 */
+		if ( ! apply_filters( 'aggregator_display_ui', true ) ) {
+			return;
+		}
+
 		add_submenu_page(
 			'settings.php',
 			__( 'Aggregator Setup' ),


### PR DESCRIPTION
A developer may want to turn off the admin UI to prevent further jobs from being created by users. This filter allows for the possibility of disabling the network admin menu item and page.