### PR TITLE
Fix parsing in prepare_terms()

### DIFF
--- a/class-aggregate.php
+++ b/class-aggregate.php
@@ -599,6 +599,11 @@ class Aggregate extends Aggregator_Plugin {
 			// Get the terms from this taxonomy attached to the post.
 			$tax_terms = get_the_terms( $post_id, $taxonomy );
 
+			// If we have no terms to pass through or got an error, skip to the next taxonomy.
+			if ( ! $tax_terms || is_wp_error( $tax_terms ) ) {
+				continue;
+			}
+
 			// Add each of the attached terms to our new array.
 			foreach ( $tax_terms as & $term ) {
 				$terms[ $taxonomy ][ $term->slug ] = $term->name; }


### PR DESCRIPTION
Added early continue for situations where a taxonomy is assigned to a cpt but a post has no terms assigned in that taxonomy.

Reference and Resolves #57 