### PR TITLE
Don't load the Jobs table during ajax requests.

### DIFF
--- a/class-aggregator.php
+++ b/class-aggregator.php
@@ -74,7 +74,10 @@ class Aggregator extends Aggregator_Plugin {
 	 */
 	function admin_init() {
 
-		$this->list_table = new Aggregator_Jobs_List_Table();
+		// Don't load the Jobs table during AJAX requests.
+		if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) {
+			$this->list_table = new Aggregator_Jobs_List_Table();
+		}
 
 		$this->set_cpt_cache();
 


### PR DESCRIPTION
Adds a simple AJAX check to make sure we don't load the jobs table during ajax request.

Fixes #56 
